### PR TITLE
Windows friendly changes

### DIFF
--- a/include/headers.h
+++ b/include/headers.h
@@ -42,7 +42,9 @@
 
 
 // Standard Library headers
+#ifndef __MINGW32__
 #include <arpa/inet.h>   /* ntohl htonl */
+#endif
 #include <string.h>      /* memcpy */
 #include <math.h>
 #include <algorithm>

--- a/src/ClientSocket.cpp
+++ b/src/ClientSocket.cpp
@@ -236,7 +236,7 @@ void ClientSession::sendMapRequest(const boost::system::error_code& error)
         
         sprintf(cmd, "");
         direction = "\r\n";
-        sleep(0.1);
+        boost::this_thread::sleep_for(boost::chrono::nanoseconds(1));
 
         boost::asio::async_write(socket_, boost::asio::buffer(command), boost::bind(&ClientSession::sizeMap, this, boost::asio::placeholders::error));
         


### PR DESCRIPTION
Ignoring inet.h is using MinGW (boost includes winsocks.h automatically I think) and use Boost's thread sleep instead of sleep()
